### PR TITLE
Fix leading whitespace error in sha256 for openllama-7b-open-instruct

### DIFF
--- a/openllama-7b-open-instruct.yaml
+++ b/openllama-7b-open-instruct.yaml
@@ -23,7 +23,7 @@ config_file: |
 
 files:
     - filename: "open-llama-7B-open-instruct.ggmlv3.q4_0.bin"
-      sha256: "	7c9b21f889d181dedab298ff3e494bce01af8a4e828fc0945985e90c96434a4d"
+      sha256: "7c9b21f889d181dedab298ff3e494bce01af8a4e828fc0945985e90c96434a4d"
       uri: "https://huggingface.co/TheBloke/open-llama-7b-open-instruct-GGML/resolve/main/open-llama-7B-open-instruct.ggmlv3.q4_0.bin"
 
 prompt_templates:


### PR DESCRIPTION
Should fix https://github.com/go-skynet/model-gallery/issues/5

The trailing whitespace at the end of line 38 was removed by the in browser edit.
The other yaml files finish also with an `### Respone:` without whitespace after `:`