### PR TITLE
Rename ggml-gpt4all-j to ggml-gpt4all-j.bin

### DIFF
--- a/bert-embeddings.yaml
+++ b/bert-embeddings.yaml
@@ -6,10 +6,10 @@ description: |
     Bert model that can be used for embeddings
 config_file: |
     parameters:
-      model: bert-MiniLM-L6-v2q4_0
+      model: bert-MiniLM-L6-v2q4_0.bin
     backend: bert-embeddings
     embeddings: true
 files:
-- filename: "bert-MiniLM-L6-v2q4_0"
+- filename: "bert-MiniLM-L6-v2q4_0.bin"
   sha256: "a5a174d8772c8a569faf9f3136c441f2c3855b5bf35ed32274294219533feaad"
   uri: "https://huggingface.co/skeskinen/ggml/resolve/main/all-MiniLM-L6-v2/ggml-model-q4_0.bin"

--- a/gpt4all-j.yaml
+++ b/gpt4all-j.yaml
@@ -7,7 +7,7 @@ urls:
 config_file: |
     backend: gpt4all-j
     parameters:
-      model: ggml-gpt4all-j
+      model: ggml-gpt4all-j.bin
       top_k: 80
       temperature: 0.2
       top_p: 0.7
@@ -17,7 +17,7 @@ config_file: |
       chat: gpt4all-chat
 
 files:
-    - filename: "ggml-gpt4all-j"
+    - filename: "ggml-gpt4all-j.bin"
       sha256: "acd54f6da1cad7c04c48b785178d686c720dcbe549903032a0945f97b1a43d20"
       uri: "https://gpt4all.io/models/ggml-gpt4all-j.bin"
 


### PR DESCRIPTION
Added file extension .bin to gpt4all-j model

Is related to: https://github.com/go-skynet/model-gallery/issues/7

Started to rename the models