### PR TITLE
Fix indentation in llama2-chat.yaml

### DIFF
--- a/llama2-chat.yaml
+++ b/llama2-chat.yaml
@@ -1,7 +1,7 @@
 name: "llama2-13b-chat"
 
 description: |
-Llama 2 13B Chat -> Llama 2 is a collection of pretrained and fine-tuned generative text models ranging in scale from 7 billion to 70 billion parameters. 
+  Llama 2 13B Chat -> Llama 2 is a collection of pretrained and fine-tuned generative text models ranging in scale from 7 billion to 70 billion parameters. 
 
 license: "https://ai.meta.com/llama/license/"
 urls:


### PR DESCRIPTION
I was getting:

> chatbot-ui-api-1      | 1:48PM INF LocalAI version: v1.22.0 (bed9570e48581fef474580260227a102fe8a7ff4)
> chatbot-ui-api-1      | 1:48PM DBG Extracting backend assets files to /tmp/localai/backend_data
> chatbot-ui-api-1      | 1:48PM ERR error: yaml: line 6: could not find expected ':'

when using

> 'PRELOAD_MODELS=[{"url": "github:go-skynet/model-gallery/llama2-chat.yaml", "name": "llama2-13b-chat"}]'