### PR TITLE
update chat message template

### DIFF
--- a/llama2-chat.yaml
+++ b/llama2-chat.yaml
@@ -26,8 +26,7 @@ prompt_templates:
   content: |
     {{if eq .RoleName "assistant"}}{{.Content}}{{else}}
     [INST]
-    {{if .SystemPrompt}}{{.SystemPrompt}}{{else if eq .RoleName "system"}}<<SYS>>{{.Content}}<</SYS>>
-
-    {{else if .Content}}{{.Content}}{{end}}
+    {{if eq .RoleName "system"}}<<SYS>>{{.Content}}<</SYS>>{{else if and (.SystemPrompt) (eq .MessageIndex 0)}}<<SYS>>{{.SystemPrompt}}<</SYS>>{{end}}
+    {{if .Content}}{{.Content}}{{end}}
     [/INST] 
     {{end}}


### PR DESCRIPTION
I've seen at least two reports in discord that the llama2-chat template was broken. From my testing, it was as well.

Earlier in the llama2-chat testing phase, I had used a slightly inverted template. From my limited testing so far, it seems that this form of template handles better.

I have tested this with:

- a single user role message only
- a single system role message before the user message
- a short conversation consisting of a system message, a user message, the assistant's reply (from the prior test), and a user reply. 

In all cases... it seems to work for me. I'd appreciate more testing!