### PR TITLE
feat: rwkv base config improvements

### DIFF
--- a/main.go
+++ b/main.go
@@ -152,7 +152,7 @@ func getSHA256(url string) (string, error) {
 	shaRegex := regexp.MustCompile(`(?s)<strong>SHA256:</strong>\s+(.+?)</li>`)
 	match := shaRegex.FindSubmatch(htmlData)
 	if len(match) < 2 {
-		return "", fmt.Errorf("SHA256 value not found in the HTML")
+		return "", fmt.Errorf("SHA256 value not found in the HTML. HTTP Status: %d", resp.StatusCode)
 	}
 
 	sha := string(match[1])

--- a/main.go
+++ b/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"os"
@@ -74,8 +74,18 @@ var baseDefinitions []BaseDefinition = []BaseDefinition{
 		Path: "openllama_3b",
 	},
 	{
+		Name:  "llama2-chat",
+		Path:  "llama2-chat",
+		Match: StripErrorFromPointer(regexp.Compile(`llama-*2-*([\d]+b)?-*chat`)),
+	},
+	{
+		Name:  "rwkv-world",
+		Path:  "rwkv-world",
+		Match: StripErrorFromPointer(regexp.Compile(`rwkv.*world`)),
+	},
+	{
 		Name: "rwkv",
-		Path: "rwkv-raven-1b",
+		Path: "rwkv-20b",
 	},
 	{
 		Name: "wizard",
@@ -84,11 +94,6 @@ var baseDefinitions []BaseDefinition = []BaseDefinition{
 	{
 		Name: "hippogriff",
 		Path: "hippogriff",
-	},
-	{
-		Name:  "llama2-chat",
-		Path:  "llama2-chat",
-		Match: StripErrorFromPointer(regexp.Compile(`llama-*2-*([\d]+b)?-*chat`)),
 	},
 }
 
@@ -139,7 +144,7 @@ func getSHA256(url string) (string, error) {
 	}
 	defer resp.Body.Close()
 
-	htmlData, err := ioutil.ReadAll(resp.Body)
+	htmlData, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", fmt.Errorf("failed to read the response body: %v\n", err)
 	}
@@ -298,7 +303,7 @@ func scrapeHuggingFace(term string, concurrency int, indexFile string) {
 	currentGallery := []GalleryModel{}
 	currentGalleryMap := map[string]GalleryModel{}
 
-	dat, err := ioutil.ReadFile(indexFile)
+	dat, err := os.ReadFile(indexFile)
 	if err == nil {
 		err = yaml.Unmarshal(dat, &currentGallery)
 		if err != nil {
@@ -340,7 +345,7 @@ func scrapeHuggingFace(term string, concurrency int, indexFile string) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	ioutil.WriteFile(indexFile, galleryYAML, 0644)
+	os.WriteFile(indexFile, galleryYAML, 0644)
 
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -1,9 +1,20 @@
 package main
 
 import (
+	"os"
 	"testing"
 )
 
+// This isn't much of a unit test - rather, this is intended to allow `go test` to serve as a developer's testing tool to see if the main process would handle a given model appropriately.
 func TestSmallSearch(t *testing.T) {
-	parallelSearch([]string{"Llama-2-13B-chat-GGML"}, 1, "_test.yaml")
+	testQuery := os.Getenv("TEST_QUERY")
+	outputPath := os.Getenv("TEST_OUTPUT")
+
+	if testQuery == "" {
+		testQuery = "Llama-2-13B-chat-GGML"
+	}
+	if outputPath == "" {
+		outputPath = "_test.yaml"
+	}
+	parallelSearch([]string{testQuery}, 1, outputPath)
 }

--- a/rwkv-20b.yaml
+++ b/rwkv-20b.yaml
@@ -1,0 +1,50 @@
+name: "rwkv-20b"
+license: "Apache 2.0"
+urls:
+- https://github.com/BlinkDL/RWKV-LM
+description: |
+    RWKV is an RNN with Transformer-level LLM performance, which can also be directly trained like a GPT transformer (parallelizable).
+    And it's 100% attention-free. You only need the hidden state at position t to compute the state at position t+1. 
+    You can use the "GPT" mode to quickly compute the hidden state for the "RNN" mode.
+    This version is quantized for ggml to work with rwkv.cpp.
+config_file: |
+  parameters:
+    top_k: 80
+    temperature: 0.9
+    max_tokens: 100
+    top_p: 0.8
+    tokenizer: "20B_tokenizer.json"
+  context_size: 1024
+  backend: "rwkv"
+  cutwords:
+  - "Bob:.*"
+  roles:
+    user: "Bob:"
+    system: "Alice:"
+    assistant: "Alice:"
+  template:
+    completion: rwkv-completion
+    chat: rwkv-chat
+files:
+- filename: "20B_tokenizer.json"
+  sha256: "56ac4821e129d2c520fdaba60abd920fa852ada51b45c0dd52bbb6bd8c985ade"
+  uri: "https://raw.githubusercontent.com/saharNooby/rwkv.cpp/e0684e81043e47c97b2a53e71a9c99648c8ed881/rwkv/20B_tokenizer.json"
+prompt_templates:
+- name: "rwkv-completion"
+  content: |
+    Complete the following sentence: {{.Input}} 
+- name: "rwkv-chat"
+  content: |
+    The following is a verbose detailed conversation between Bob and a woman, Alice. Alice is intelligent, friendly and likeable. Alice is likely to agree with Bob.
+
+    Bob: Hello Alice, how are you doing?
+
+    Alice: Hi Bob! Thanks, I'm fine. What about you?
+
+    Bob: I am very good! It's nice to see you. Would you mind me chatting with you for a while?
+
+    Alice: Not at all! I'm listening.
+
+    {{.Input}}
+
+    Alice: 

--- a/rwkv-world.yaml
+++ b/rwkv-world.yaml
@@ -1,0 +1,44 @@
+name: "rwkv-20b"
+license: "Apache 2.0"
+urls:
+- https://github.com/BlinkDL/RWKV-LM
+description: |
+    RWKV is an RNN with Transformer-level LLM performance, which can also be directly trained like a GPT transformer (parallelizable).
+    And it's 100% attention-free. You only need the hidden state at position t to compute the state at position t+1. 
+    You can use the "GPT" mode to quickly compute the hidden state for the "RNN" mode.
+    This version is quantized for ggml to work with rwkv.cpp.
+config_file: |
+  parameters:
+    top_k: 80
+    temperature: 0.9
+    max_tokens: 100
+    top_p: 0.8
+    tokenizer: "rwkv_vocab_v20230424.txt"
+  context_size: 1024
+  backend: "rwkv"
+  cutwords:
+  - "Answer:.*"
+  roles:
+    user: "Question:"
+    system: "Answer:"
+    assistant: "Answer:"
+  template:
+    completion: rwkv-completion
+    chat: rwkv-chat
+files:
+- filename: "rwkv_vocab_v20230424.txt"
+  sha256: ""
+  uri: "https://raw.githubusercontent.com/saharNooby/rwkv.cpp/master/rwkv/rwkv_vocab_v20230424.txt"
+prompt_templates:
+- name: "rwkv-completion"
+  content: |
+    Complete the following sentence: {{.Input}} 
+- name: "rwkv-chat"
+  content: |
+    User: hi
+
+    Assistant: Hi. I am your assistant and I will provide expert full response in full details. Please feel free to ask any question and I will always answer it.
+
+    User: {{.Input}}
+
+    Assistant:


### PR DESCRIPTION
Introduces two new base configs for RWKV models - one for the 20B tokenizer format, and one for the world tokenizer format. Combined with https://github.com/go-skynet/LocalAI/pull/937, this should enable the model gallery to support all RWKV models that I'm aware of