### PR TITLE
Add Mixtral 8x7B Q3 and Q6 configurations

### DIFF
--- a/mixtral-Q3.yaml
+++ b/mixtral-Q3.yaml
@@ -1,4 +1,4 @@
-name: "mixtral-8x7B-Q6_K"
+name: "mixtral-8x7B-Q3_K_M"
 
 description: |
   This is a mixtral model
@@ -8,14 +8,14 @@ urls:
 - https://huggingface.co/TheBloke/Mixtral-8x7B-Instruct-v0.1-GGUF
 
 config_file: |
-  name: mixtral-8x7B-Q6_K
+  name: mixtral-8x7B-Q3_K_M
   context_size: 4096
   f16: true
   mmap: true
-  gpu_layers: 200 # Comment out to disable offloading to GPU
-  threads: 24
+  #gpu_layers: 200 # uncomment to offload all layers to GPU
+  threads: 8
   parameters:
-    model: mixtral-8x7b-instruct-v0.1.Q6_K.gguf
+    model: mixtral-8x7b-instruct-v0.1.Q3_K_M.gguf
     temperature: 0.2
     top_k: 40
     top_p: 0.95
@@ -37,6 +37,6 @@ prompt_templates:
     [INST] {{.Input}} [/INST]
     
 files:
-- filename: "mixtral-8x7b-instruct-v0.1.Q6_K.gguf"
-  sha256: "56638f9853b8fff80ac1fd4a91434a1c15c21d4c910811c5458df9ef092615fd"
-  uri: "https://huggingface.co/TheBloke/Mixtral-8x7B-Instruct-v0.1-GGUF/resolve/main/mixtral-8x7b-instruct-v0.1.Q6_K.gguf"
+- filename: "mixtral-8x7b-instruct-v0.1.Q3_K_M.gguf"
+  sha256: "bd2e1499e68195f1a6ff151e6fa5c6632acc150b80cca4a3772cbb7ca59d44cd"
+  uri: "https://huggingface.co/TheBloke/Mixtral-8x7B-Instruct-v0.1-GGUF/resolve/main/mixtral-8x7b-instruct-v0.1.Q3_K_M.gguf"

--- a/mixtral-Q6.yaml
+++ b/mixtral-Q6.yaml
@@ -1,0 +1,42 @@
+name: "mixtral-8x7B-Q6_K"
+
+description: |
+  This is a mixtral model
+
+license: "https://ai.meta.com/llama/license/"
+urls:
+- https://huggingface.co/TheBloke/Mixtral-8x7B-Instruct-v0.1-GGUF
+
+config_file: |
+  name: mixtral-8x7B-Q6_K
+  context_size: 4096
+  f16: true
+  mmap: true
+  gpu_layers: 200
+  threads: 24
+  parameters:
+    model: mixtral-8x7b-instruct-v0.1.Q6_K.gguf
+    temperature: 0.2
+    top_k: 40
+    top_p: 0.95
+    frequency_penalty: 1.1
+    batch: 512
+    tfz: 1.0
+  template:
+    chat: mixtral-chat
+    completion: mixtral-completion
+  stopwords:
+  - <|im_end|>
+
+prompt_templates:
+- name: "mixtral-chat"
+  content: |
+    [INST] {{.Input}} [/INST]
+- name: "mixtral-completion"
+  content: |
+    [INST] {{.Input}} [/INST]
+    
+files:
+- filename: "mixtral-8x7b-instruct-v0.1.Q6_K.gguf"
+  sha256: "56638f9853b8fff80ac1fd4a91434a1c15c21d4c910811c5458df9ef092615fd"
+  uri: "https://huggingface.co/TheBloke/Mixtral-8x7B-Instruct-v0.1-GGUF/resolve/main/mixtral-8x7b-instruct-v0.1.Q6_K.gguf"


### PR DESCRIPTION
I added configurations for mixtral-8x7B instruct using Q6_K and Q3_K_M quantizations in this PR. These models are licensed unambiguously as [Apache 2.0](https://mistral.ai/news/mixtral-of-experts/). The Q6 quantization configuration is setup for fully offloading to GPU, while the Q3 is setup for CPU inference; I didn't see guidance on which is the preferred setup but I would be happy to update these configurations to match a preferred default.

I did notice occasional weirdness and garbling with the output using [ChatGPT Next Web](https://github.com/ChatGPTNextWeb/ChatGPT-Next-Web) as the client, but it could be due to the event stream voodoo that client uses 🤷.